### PR TITLE
Make rules opt-in: all disabled by default

### DIFF
--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -3,6 +3,11 @@ name: PR Auto Labeler
 on:
   workflow_call:
     inputs:
+      enabled_rules:
+        description: 'List of rule names to enable (JSON array). All rules disabled by default. Example: ["frontend-ui", "env-variables"]'
+        required: false
+        type: string
+        default: '[]'
       label_overrides:
         description: 'Custom label names to override defaults (JSON)'
         required: false
@@ -40,6 +45,7 @@ jobs:
       - name: Analyze changes and apply labels
         uses: actions/github-script@v7
         env:
+          ENABLED_RULES: ${{ inputs.enabled_rules }}
           ENABLE_DEBUG: ${{ inputs.enable_debug }}
           LABEL_OVERRIDES: ${{ inputs.label_overrides }}
           SKIP_LABELS: ${{ inputs.skip_labels }}
@@ -47,20 +53,22 @@ jobs:
         with:
           script: |
             // ==============================================================
-            // PR Auto-Labeler - Dynamic Rule Loading System
+            // PR Auto-Labeler - Dynamic Rule Loading System with Opt-in
             // ==============================================================
-            // This workflow automatically discovers and loads all rules from
-            // the src/rules/ directory. Contributors only need to add a new
-            // rule file - no need to modify this workflow!
+            // This workflow discovers rules from src/rules/ directory.
+            // ALL RULES ARE DISABLED BY DEFAULT - you must explicitly enable them!
+            //
+            // To enable rules, pass them in enabled_rules input:
+            // enabled_rules: '["frontend-ui", "env-variables"]'
             //
             // To add a new rule:
             // 1. Create a new .js file in src/rules/ (e.g., my-rule.js)
             // 2. Follow the rule template format
             // 3. Submit a PR with just that file!
-            //
-            // That's it! The workflow will automatically discover and run it.
+            // 4. Users enable it in their workflow configuration
             // ==============================================================
             
+            const enabledRules = JSON.parse(process.env.ENABLED_RULES || '[]');
             const enableDebug = process.env.ENABLE_DEBUG === 'true';
             const labelOverrides = JSON.parse(process.env.LABEL_OVERRIDES || '{}');
             const skipLabels = JSON.parse(process.env.SKIP_LABELS || '[]');
@@ -79,6 +87,15 @@ jobs:
               console.log('=== PR Auto-Labeler Starting ===');
               console.log(`PR #${prNumber}: ${pr.title}`);
               console.log(`Files changed: ${files.length}`);
+              console.log(`Enabled rules: ${enabledRules.length > 0 ? enabledRules.join(', ') : 'NONE (all rules disabled)'}`);
+            }
+            
+            // Check if any rules are enabled
+            if (enabledRules.length === 0) {
+              console.log('⚠️  No rules enabled. All labels are disabled by default.');
+              console.log('💡 To enable rules, add enabled_rules input to your workflow:');
+              console.log('   enabled_rules: \'["frontend-ui", "env-variables"]\'');
+              return;
             }
             
             // ==============================================================
@@ -117,8 +134,19 @@ jobs:
                 console.log(`Found ${jsFiles.length} rule files: ${jsFiles.map(f => f.name).join(', ')}`);
               }
               
-              // Load each rule file
+              // Load each rule file (only if enabled)
               for (const file of jsFiles) {
+                // Extract rule name from filename (remove .js extension)
+                const ruleName = file.name.replace('.js', '');
+                
+                // Check if this rule is enabled
+                if (!enabledRules.includes(ruleName)) {
+                  if (enableDebug) {
+                    console.log(`⏭️  Skipping disabled rule: ${ruleName}`);
+                  }
+                  continue;
+                }
+                
                 try {
                   // Fetch the rule file content
                   const { data: fileData } = await github.rest.repos.getContent({
@@ -139,7 +167,7 @@ jobs:
                   if (typeof ruleFunction === 'function') {
                     rules.push(ruleFunction);
                     if (enableDebug) {
-                      console.log(`✅ Loaded rule: ${ruleFunction.metadata?.name || file.name}`);
+                      console.log(`✅ Loaded enabled rule: ${ruleFunction.metadata?.name || file.name}`);
                     }
                   }
                 } catch (error) {

--- a/README.md
+++ b/README.md
@@ -56,33 +56,46 @@ permissions:
 jobs:
   label:
     uses: workflow-kit/pr-auto-labeler/.github/workflows/pr-auto-labeler.yml@main
+    with:
+      # Enable the rules you want to use
+      enabled_rules: '["frontend-ui", "env-variables"]'
 ```
 
 ### Step 2: That's It!
 
 Create a pull request and watch the magic happen! 🎉
 
+> **💡 Note:** Rules are disabled by default. You must specify which rules to enable using the `enabled_rules` parameter. See [Current Rules](#-current-rules) for available options.
+
 ## ⚙️ Configuration
+
+### ⚠️ Important: Rules are Disabled by Default
+
+**All rules are disabled by default.** You must explicitly enable the rules you want to use.
 
 ### Basic Configuration
 
-Customize behavior with input parameters:
+Enable rules and customize behavior with input parameters:
 
 ```yaml
 jobs:
   label:
     uses: workflow-kit/pr-auto-labeler/.github/workflows/pr-auto-labeler.yml@main
     with:
-      # Enable debug logging (default: false)
+      # ✅ REQUIRED: Enable specific rules (JSON array)
+      # All rules are disabled by default
+      enabled_rules: '["frontend-ui", "env-variables"]'
+      
+      # Optional: Enable debug logging (default: false)
       enable_debug: true
       
-      # Threshold for large PR detection (default: 500)
+      # Optional: Threshold for large PR detection (default: 500)
       large_pr_threshold: 800
       
-      # Override default label names (JSON object)
+      # Optional: Override default label names (JSON object)
       label_overrides: '{"ui-change":"frontend-change"}'
       
-      # Skip specific labels (JSON array)
+      # Optional: Skip specific labels (JSON array)
       skip_labels: '["style-change"]'
 ```
 
@@ -90,6 +103,7 @@ jobs:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| `enabled_rules` | JSON Array | `[]` | **Rules to enable** (all disabled by default). See [Available Rules](#-current-rules) |
 | `label_overrides` | JSON Object | `{}` | Map default labels to custom names |
 | `large_pr_threshold` | Number | `500` | Lines changed to trigger `large-pr` label |
 | `enable_debug` | Boolean | `false` | Enable detailed debug logging |
@@ -134,9 +148,17 @@ This will show detailed logs including:
 
 ## 📚 Current Rules
 
+> **💡 Remember:** All rules are disabled by default. Add them to `enabled_rules` to use them!
+
 ### 🎨 Frontend/UI Detection
+**Rule Name:** `frontend-ui` 
 
 Detects changes to frontend and UI files.
+
+**Enable:**
+```yaml
+enabled_rules: '["frontend-ui"]'
+```
 
 **Labels Applied:**
 - **`ui-change`** (🟢 Green): UI/Frontend files modified
@@ -151,6 +173,35 @@ PR modifies: index.html, styles.css
 
 PR modifies: App.jsx, styles.css
 → Labels: ui-change (only)
+```
+
+---
+
+### 🔐 Environment Variables Detection
+**Rule Name:** `env-variables`
+
+Detects changes to environment files and flags potential secrets.
+
+**Enable:**
+```yaml
+enabled_rules: '["env-variables"]'
+```
+
+**Labels Applied:**
+- **`env-change`**: Environment configuration files modified
+  - Triggered by: `.env`, `.env.*`, `config.yml`, `config.yaml`, `config.json`
+- **`new-env-variable`**: New environment variable introduced
+  - Detected in git diffs with new lines containing `KEY=value` patterns
+- **`potential-secret-leak`**: Potential secret or sensitive data detected
+  - Flags variables containing: `API_KEY`, `PASSWORD`, `SECRET`, `TOKEN`, `PRIVATE_KEY`, `CREDENTIAL`
+
+**Example:**
+```
+PR adds: .env.production with API_KEY=sk_live_123
+→ Labels: env-change, new-env-variable, potential-secret-leak
+
+PR modifies: config.yml (existing keys only)
+→ Labels: env-change (only)
 ```
 
 ---
@@ -316,14 +367,21 @@ on:
 **Problem**: Workflow runs but no labels are applied
 
 **Solutions**:
-1. Enable debug mode to see what's happening:
+1. **Most Common:** Verify you've enabled rules. All rules are disabled by default!
+   ```yaml
+   with:
+     enabled_rules: '["frontend-ui", "env-variables"]'
+   ```
+2. Enable debug mode to see what's happening:
    ```yaml
    with:
      enable_debug: true
    ```
-2. Check the workflow logs in the Actions tab
-3. Verify PR contains files that match rule criteria
-4. Check if labels are being skipped via `skip_labels`
+3. Check the workflow logs in the Actions tab for messages like:
+   - `⚠️ No rules enabled`
+   - `⚠️ No rules loaded`
+4. Verify PR contains files that match rule criteria
+5. Check if labels are being skipped via `skip_labels`
 
 ### Permission Denied
 


### PR DESCRIPTION
## Changes

This PR implements an opt-in system for rules, where all rules are disabled by default and must be explicitly enabled by users.

### Key Changes

1. **New Input Parameter:** `enabled_rules`
   - Accepts a JSON array of rule names to enable
   - Example: `'["frontend-ui", "env-variables"]`
   - Default: `[]` (empty = no rules enabled)

2. **Rule Loading Logic**
   - Only loads and executes rules that are in the `enabled_rules` list
   - Checks filename (without .js extension) against enabled rules
   - Provides clear feedback when no rules are enabled

3. **Updated Documentation**
   - README updated with prominent warnings about opt-in requirement
   - Configuration section reorganized to highlight `enabled_rules` first
   - Current Rules section now shows how to enable each rule
   - Troubleshooting section updated with common issue

### Benefits

- ✅ Users have full control over which rules to use
- ✅ No unexpected label spam on existing repos
- ✅ Easier to test individual rules
- ✅ Better security/privacy (e.g., skip env-variables rule if concerned)
- ✅ More scalable as we add more rules

### Migration Guide

Existing users need to add `enabled_rules` to their workflow:

```yaml
with:
  enabled_rules: '["frontend-ui", "env-variables"]'
```

Without this, no labels will be applied (workflow will log a helpful message).

### Testing

- [x] Workflow syntax validated
- [ ] Will test in demo-app after merge